### PR TITLE
Fix the Makefile for native compiling

### DIFF
--- a/am335x_pru_package/pru_sw/example_apps/Makefile
+++ b/am335x_pru_package/pru_sw/example_apps/Makefile
@@ -5,7 +5,12 @@ LIBDIR_APP_LOADER?=../../app_loader/lib
 INCDIR_APP_LOADER?=../../app_loader/include
 BINDIR_APPLICATIONS?=../bin
 BINDIR_FW?=bin
-PASM?=../utils/pasm_2
+
+ifeq ($(CROSS_COMPILE),"arm-angstrom-linux-gnueabi-")
+ PASM?=../utils/pasm_2
+else
+ PASM?=../utils/pasm
+endif
 
 all:
 # Make PRU example applications


### PR DESCRIPTION
When used in the BB(B), the PASM is named pasm instead of pasm_2.
